### PR TITLE
Updated tasks.rs to add error message to coverage

### DIFF
--- a/xtaskops/src/tasks.rs
+++ b/xtaskops/src/tasks.rs
@@ -122,7 +122,8 @@ pub fn coverage(devmode: bool) -> AnyResult<()> {
         "-o",
         file,
     )
-    .run()?;
+    .run()
+    .context("This command can fail if grcov is not installed.\nInstall it by running 'cargo install grcov'")?;
     println!("ok.");
 
     println!("=== cleaning up ===");


### PR DESCRIPTION
I have written an error message to inform the user to install grcov if the coverage task fails, this should mitigate #2