### PR TITLE
Implementation to resolve issue #7

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,4 +13,4 @@ duct = "0.13.5"
 glob = "0.3.0"
 fs_extra = "1"
 dialoguer = "^0.10.1"
-xtaskops = { path = "../xtaskops" }
+xtaskops = { path = "../xtaskops", features = [ "excludes" ] }

--- a/xtaskops/Cargo.toml
+++ b/xtaskops/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtaskops"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 description = "Goodies for working with the xtask concept"

--- a/xtaskops/Cargo.toml
+++ b/xtaskops/Cargo.toml
@@ -15,6 +15,7 @@ readme = "../README.md"
 [features]
 default = ["clap"]
 clap = ["dep:clap"]
+excludes = []
 
 [dependencies]
 derive_builder = "^0.12.0"

--- a/xtaskops/src/tasks.rs
+++ b/xtaskops/src/tasks.rs
@@ -100,8 +100,7 @@ pub fn coverage(devmode: bool) -> AnyResult<()> {
     } else {
         ("lcov", "coverage/tests.lcov")
     };
-    cmd!(
-        "grcov",
+    let mut args=vec!(
         ".",
         "--binary-path",
         "./target/debug/deps",
@@ -109,6 +108,17 @@ pub fn coverage(devmode: bool) -> AnyResult<()> {
         ".",
         "-t",
         fmt,
+    );
+    #[cfg(feature="excludes")]
+    args.append(&mut vec!(
+        "--excl-line",
+        "GRCOV_EXCL_LINE",
+        "--excl-start",
+        "GRCOV_EXCL_START",
+        "--excl-stop",
+        "GRCOV_EXCL_STOP",
+    ));
+    args.append(&mut vec!(
         "--branch",
         "--ignore-not-existing",
         "--ignore",
@@ -121,8 +131,8 @@ pub fn coverage(devmode: bool) -> AnyResult<()> {
         "*/src/tests/*",
         "-o",
         file,
-    )
-    .run()?;
+        ));
+    cmd("grcov", &args).run()?;
     println!("ok.");
 
     println!("=== cleaning up ===");


### PR DESCRIPTION
Here's an implementation of a feature that adds the "--excl-line, --excl-start, and --excl-stop" arguments to the coverage task.

It uses the "excludes" feature to add in those extra parameters setting the markers as
GRCOV_EXCL_LINE
GRCOV_EXCL_START
GRCOV_EXCL_STOP

The xtask that allows coverage to be run includes this option to drive the code, although there are no markers in this project for it to hit.